### PR TITLE
Add gcc-multilib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     llvm-dev \
     g++ \
     gcc \
+    gcc-multilib \
     git \
     libtool \
     libtool-bin \


### PR DESCRIPTION
Hey man I was screwing around with this today. I'm targeting Avast's JS [Engine](https://github.com/taviso/avscript) which is 32bit. This adds the ability for AFL to cross-compile targets using AFL LLVM modes. If gcc-multilib is installed AFL will generate afl-llvm-rt-32.o. which downstream means afl-clang-fast(++) can cross compile properly.

Not sure if you're still wanting to have anything to do with this project, feel free to close :p 